### PR TITLE
[codex] fail closed lfg detect

### DIFF
--- a/CHANGELOG_RELEASE.md
+++ b/CHANGELOG_RELEASE.md
@@ -3,4 +3,4 @@
 Full changelog in the repository:
 https://github.com/byi77/isilive/blob/main/docs/CHANGELOG.md
 
-Current release: `0.9.151`.
+Current release: `0.9.153`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 WoW Mythic+ group helper addon focused on pre-key group overview and in-key tracking.
 
 Compatibility: WoW `12.0+` only.
-Current version: `0.9.151`.
+Current version: `0.9.153`.
 
 ---
 
@@ -53,7 +53,7 @@ Current version: `0.9.151`.
 - Short code rendered on icon when portal is ready; hidden during cooldown
 - Portal targets highlighted only from active listing or exact synced target data — never guessed
 - Portal-ready feedback uses `sounds/Portal.ogg` once when a teleport target becomes available
-- **LFG detection:** when the player accepts an LFG group invite or creates their own LFG queue listing, the matching portal icon is highlighted automatically (gold border + glow animation); the invite/listing notice is locale-aware and emitted once per recognized target change; highlight clears when the queue is cancelled, the group dissolves, or the key starts
+- **LFG detection:** when the player receives an LFG group invite or creates their own LFG queue listing, the matching portal icon is highlighted automatically (gold border + glow animation) without the portal sound; the invite/listing notice is locale-aware and emitted once per recognized target change; highlight clears when the queue is cancelled, the group dissolves, or the key starts
 
 ### Addon Sync
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # isiLive Architektur
 
-Versionsbasis: `0.9.151`
+Versionsbasis: `0.9.153`
 Zuletzt aktualisiert: `2026-04-13`
 
 ## Zweck
@@ -103,14 +103,14 @@ Lokale Release-Qualitaet ist absichtlich in statische und Runtime-Gates aufgetei
    - `lua tools/validate_usecases.lua`
 3. `tools/validate_rules_logic.lua` validiert aktive Vertraege aus `RULES_LOGIC.md` gegen deterministische Testnamen.
 4. `tools/validate_architecture_rules.lua` validiert aktive Architekturvertraege aus `ARCHITECTURE_RULES.md` gegen deterministische Testnamen.
-5. `tools/validate_usecases.lua` fuehrt beide Validatoren zuerst aus und deckt danach 556 Szenarien ueber 40 Module ab; die Regelvalidatoren indizieren aktuell 556 deterministische Tests.
+5. `tools/validate_usecases.lua` fuehrt beide Validatoren zuerst aus und deckt danach 559 Szenarien ueber 40 Module ab; die Regelvalidatoren indizieren aktuell 559 deterministische Tests.
 
 Die lokalen Wrapper `tools/check.ps1` und `tools/check.cmd` sind der bevorzugte Einstiegspunkt fuer das statische Gate, weil sie `luacheck` ueber den repo-lokalen Windows-Shim routen, statt direkt das LuaRocks-Script aufzurufen.
 
 ## UI-Struktur (ASCII-Skizze)
 
 ```text
-| isiLive                                                 v0.9.151 Open/Close CTRL-F9 [H][V][M][M2][L][X]|
+| isiLive                                                 v0.9.153 Open/Close CTRL-F9 [H][V][M][M2][L][X]|
 |---------------------------------------------------------------------------------------------------|
 | Spec   Name         Flag Key     iLvl RIO        DPS                M+Managment  Marker    Travel  |
 |---------------------------------------------------------------------------------------------------|

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026-04-13 - Version 0.9.153 (patch)
+
+- **No-guess LFG hardening:**
+  - Removed dungeon-name and token-based fallback resolution from `isiLive_lfg_detect.lua` so invite and listing detection now stays unresolved unless exact activity data is available.
+  - Moved invite state to a pending-confirmation flow and kept the portal highlight/sound dispatch deterministic on the exact confirmation path.
+  - Updated the deterministic LFG coverage and rule-to-test mapping to enforce the fail-closed no-guess contract.
+
+## 2026-04-13 - Version 0.9.152 (patch)
+
+- **LFG invite highlight fix:**
+  - Incoming LFG invites now stay pending until the exact activity data is confirmed; the matching portal icon highlights on `inviteaccepted` instead of guessing from dungeon names.
+  - Portal sounds are suppressed for invite-driven and queue-driven target refreshes; the sound remains reserved for actual active-target changes.
+  - Updated the deterministic LFG and TeleportUI coverage to lock in the invite-silent highlight path and the fail-closed no-guess flow.
+  - Updated the validator baseline references to `559` scenarios / tests over `40` modules.
+
 ## 2026-04-13 - Version 0.9.151 (patch)
 
 - **LFG detection hardening:**

--- a/docs/RULES_LOGIC.md
+++ b/docs/RULES_LOGIC.md
@@ -621,11 +621,14 @@ Diese Datei ist die verbindliche Quelle fuer Usecase- und Runtime-Regeln, die im
 - Zusammenfassung: Wenn fuer eine Runtime-Aufloesung keine eindeutige, belastbare Quelle vorliegt, muss das Ergebnis unresolved bleiben. Fehlende oder mehrdeutige Laufzeitdaten duerfen nicht durch spekulative Fallbacks, Namens-/Token-Raten, heuristische Standardwerte oder synthetische Cooldown-/Map-Zustaende ersetzt werden. Eindeutige Aufloesungen duerfen nur aus beobachteten Live-Daten, explizit persistierten verifizierten Daten oder eindeutig bestimmten Runtime-Zusammenhaengen entstehen.
 - Erforderliche Tests:
   - Factory target dungeon stays unresolved without queue or joined-key map context
-  - Factory target dungeon resolves from synced exact target context
-  - Factory target dungeon stays unresolved on conflicting synced exact targets
-  - Teleport does not resolve by dungeon name without activityID
-  - Teleport keeps activity unresolved when mapID is missing and retries unresolved lookups
-  - Teleport short-code resolver keeps unknown maps unresolved instead of showing map ids
+- Factory target dungeon resolves from synced exact target context
+- Factory target dungeon stays unresolved on conflicting synced exact targets
+- Teleport does not resolve by dungeon name without activityID
+- Teleport keeps activity unresolved when mapID is missing and retries unresolved lookups
+- Teleport short-code resolver keeps unknown maps unresolved instead of showing map ids
+- LFGDetect keeps unknown invite activity unresolved instead of guessing from dungeon name
+- LFGDetect active listing stays unresolved when only dungeon name text is available
+- LFGDetect exact invite stays pending until inviteaccepted and then highlights without sound
 
 ### RULE-MAIN-UI-POSITION-LOCK
 - Regelnummer: 55

--- a/docs/USECASES.md
+++ b/docs/USECASES.md
@@ -1,6 +1,6 @@
 # isiLive Anwendungsfaelle
 
-Versionsbasis: `0.9.151`
+Versionsbasis: `0.9.153`
 Zuletzt aktualisiert: `2026-04-13`
 
 ## Akteure
@@ -175,11 +175,11 @@ Ziel: Live-BRes, Bloodlust/Heroism/Time Warp, aktive Mythic+-Timer-Cutoffs und g
 Ziel: LFG-Einladungen und eigene Listings sollen das Portal-Highlight und die Chat-Hinweise deterministisch ausloesen, ohne Pending-Invite-Races oder Sprach-Fallbacks.
 
 1. Trigger: `LFG_LIST_APPLICATION_STATUS_UPDATED` meldet `invited` oder `inviteaccepted`, oder `LFG_LIST_ACTIVE_ENTRY_UPDATE` meldet eine eigene aktive Listing-Info.
-2. Verarbeitung: Der Status wird kleingeschrieben normalisiert; die Activity-zu-Map-Aufloesung nutzt die statische Tabelle als ersten Pfad und darf nur bei fehlender Aktivitaet auf Namensmatching zurueckfallen.
-3. Verarbeitung: Die Chatmeldung wird ueber die locale-injizierte Texttabelle ausgegeben; Pending-Invites bleiben bis zum finalen Join oder zum Full-Reset erhalten.
-4. Regel: Eine eigene Queue-/Listing-Detektion triggert das Portal-Highlight ueber den injizierten Callback; Portal-Sound bleibt fuer Queue-getriebene Updates unterdrueckt.
+2. Verarbeitung: Der Status wird kleingeschrieben normalisiert; die Activity-zu-Map-Aufloesung nutzt nur exakte Aktivitaetsdaten. Namen, Tokens oder andere heuristische Fallbacks bleiben unresolved.
+3. Verarbeitung: Der Invite-Kontext bleibt bis zur exakten Bestaetigung per `inviteaccepted` pending; danach wird der erkannte Dungeon-Zielzustand gesetzt und das Portal-Highlight ohne Sound aktiviert. Die locale-injizierte Chatmeldung bleibt an den Invite-/Join-Confirm-Pfad gebunden.
+4. Regel: Eine eigene Queue-/Listing-Detektion triggert das Portal-Highlight ueber den injizierten Callback; Portal-Sound bleibt fuer Queue- und Invite-getriebene Updates unterdrueckt.
 5. Regel: `GROUP_ROSTER_UPDATE` ohne Gruppe sowie `CHALLENGE_MODE_START` loeschen den gesamten LFG-Zustand inklusive pending invites.
-6. Erfolgskriterium: Erkennungen erscheinen einmalig und lokalisiert, late `inviteaccepted`-Events bleiben korrekt aufloesbar, und identische Listing-Updates erzeugen keinen inkonsistenten Highlight-State.
+6. Erfolgskriterium: Erkennungen erscheinen einmalig und lokalisiert, late `inviteaccepted`-Events bleiben korrekt aufloesbar, identische Listing-Updates erzeugen keinen inkonsistenten Highlight-State, und unbekannte Namen werden nie als Dungeon-Ziel geraten.
 
 ## Nichtfunktionale Regeln
 
@@ -204,7 +204,7 @@ Ziel: LFG-Einladungen und eigene Listings sollen das Portal-Highlight und die Ch
 
 Das Runtime-Verhalten in diesem Dokument wird von `tools/validate_usecases.lua` validiert.
 Aktive Regelvertraege aus `RULES_LOGIC.md` werden von `tools/validate_rules_logic.lua` validiert und ebenfalls waehrend `tools/validate_usecases.lua` erzwungen.
-Aktuelle Validator-Baseline: `556` Szenarien ueber `40` Module.
+Aktuelle Validator-Baseline: `559` Szenarien ueber `40` Module.
 
 1. UC-01 und UC-02: strikte Queue-Target-Aufloesung und Queue-Highlight-Verhalten ohne spekulativen Fallback.
 2. UC-03: Exact-Map-Suppression und Umgang mit Shared-Portcast-Mehrdeutigkeit.
@@ -217,7 +217,7 @@ Aktuelle Validator-Baseline: `556` Szenarien ueber `40` Module.
 9. UC-11 und UC-12: Secure-World-Marker-Button-Konfiguration fuer M+Marker und Compact-Layout-Visibility-Logik fuer M/V/H.
 10. Taint-Hardening: verschobene Secure-Attribute-Writes, verschobene `Esc`-Shortcut-Secure-Button-Refreshes, insecure Teleport-Grid-Aktionen und combat-sicheres Collapse-Handling.
 11. UC-13 und UC-14: Game-Menu-Tooling-/Travel-Strips, Lokalisierung, Close-then-Open-Verhalten, verschobener Secure-Reload-Button-Refresh, Direct-Opener-Fallback-Auswahl, Settings-Canvas-State-Mirroring, Background-Opacity-Verhalten, Live-BRes-/Bloodlust-/M+-Timer-Rendering und gesyncte Interrupt-Cooldown-Anzeige.
-12. UC-15: LFG-Detektion, locale-aware Chat-Hinweise, pending-invite Race-Hardening und Highlight-Dispatch.
+12. UC-15: LFG-Detektion ohne Name-Fallbacks, locale-aware Chat-Hinweise, pending-invite Race-Hardening und Highlight-Dispatch.
 
 ## Rueckverfolgbarkeit zu Quelldateien
 

--- a/game/isiLive_lfg_detect.lua
+++ b/game/isiLive_lfg_detect.lua
@@ -29,53 +29,10 @@ local ACTIVITY_TO_MAP = {
   [1160] = 402, -- Algeth'ar Academy
 }
 
--- Normalise a string for keyword matching: lowercase, strip non-word chars,
--- collapse whitespace. Stripping non-ASCII avoids broken multibyte sequences
--- from tainted/locale LFG API strings.
-local function Norm(s)
-  local ok, result = pcall(function()
-    s = (s or ""):lower()
-    s = s:gsub("[^%a%d%'%s]", " ")
-    s = s:gsub("%s+", " ")
-    s = s:gsub("^%s", ""):gsub("%s$", "")
-    return s
-  end)
-  return ok and result or ""
-end
-
--- Keyword triggers per mapID — fallback when activity ID lookup fails.
--- Use short ASCII substrings that appear in both enUS and deDE names,
--- plus locale-specific variants where needed.
-local MAP_TRIGGERS = {
-  [557] = { "windrunner", "spire", "windl" }, -- "Windrunner Spire" / "Windläuferturm"
-  [558] = { "magister", "terrace" }, -- "Magisters' Terrace" / "Terrasse der Magister"
-  [559] = { "nexus", "xenas" }, -- "Nexus-Point Xenas" / "Nexuspunkt Xenas"
-  [560] = { "maisara", "caverns", "kavernen" }, -- "Maisara Caverns" / "Maisarakavernen"
-  [402] = { "algethar", "algeth", "academy", "akademie" }, -- "Algeth'ar Academy" / "Akademie von Algeth'ar"
-  [556] = { "saron", "pit" }, -- "Pit of Saron" / "Grube von Saron"
-  [239] = { "triumvirate", "triumvirats" }, -- "Seat of the Triumvirate" / "Sitz des Triumvirats"
-  [161] = { "skyreach", "himmelsnadel" }, -- "Skyreach" / "Die Himmelsnadel"
-}
-
-local function MatchMapIDFromName(name)
-  local n = Norm(name)
-  if n == "" then
-    return nil
-  end
-  for mapID, triggers in pairs(MAP_TRIGGERS) do
-    for _, trig in ipairs(triggers) do
-      if n:find(trig, 1, true) then
-        return mapID
-      end
-    end
-  end
-  return nil
-end
-
 -- Resolve mapID from a single activityID.
 -- Resolution order:
 --   1. ACTIVITY_TO_MAP  — static, zero-latency, taint-safe (primary)
---   2. Name-based keyword matching — fallback for activity stubs without a mapID field
+--   2. unresolved       — if no exact mapping exists, no guess is made
 local function MapIDFromActivityID(activityID)
   if not activityID then
     return nil
@@ -88,32 +45,6 @@ local function MapIDFromActivityID(activityID)
   -- 1. Static map: fast, taint-safe, reliable even when the API cache is cold
   if ACTIVITY_TO_MAP[numID] then
     return ACTIVITY_TO_MAP[numID]
-  end
-
-  -- 2. Name-based keyword fallback (handles activity stubs without a mapID field)
-  local C_LFGList_ref = rawget(_G, "C_LFGList")
-  if type(C_LFGList_ref) ~= "table" then
-    return nil
-  end
-
-  local fullName = nil
-  if type(C_LFGList_ref.GetActivityFullName) == "function" then
-    local ok, result = pcall(C_LFGList_ref.GetActivityFullName, numID)
-    if ok then
-      fullName = result
-    end
-  end
-  if not fullName or fullName == "" then
-    if type(C_LFGList_ref.GetActivityInfoTable) == "function" then
-      local ok, info = pcall(C_LFGList_ref.GetActivityInfoTable, numID)
-      if ok and type(info) == "table" then
-        fullName = info.fullName or info.shortName
-      end
-    end
-  end
-
-  if type(fullName) == "string" and fullName ~= "" then
-    return MatchMapIDFromName(fullName)
   end
 
   return nil
@@ -159,7 +90,7 @@ end
 local pendingInvites = {}
 -- mapID of the last detected own queue listing (nil = no active listing)
 local lastQueueMapID = nil
--- mapID currently highlighted (invite accepted or own queue) — nil = none
+-- mapID currently highlighted (invite or accepted invite, or own queue) — nil = none
 local detectedMapID = nil
 
 -- Injected by the factory after UpdateMPlusTeleportButton is available.
@@ -169,6 +100,7 @@ local highlightCallback = nil
 -- Injected by the factory so chat messages follow the player's locale setting.
 -- MINOR-1 fix: removes hardcoded German strings.
 local localeGetter = nil
+local TriggerHighlightUpdate = nil
 
 function LFGDetect.GetDetectedMapID()
   return detectedMapID
@@ -213,23 +145,14 @@ local function OnInvited(searchResultID)
     mapID = MapIDFromActivityID(info.activityID)
   end
 
-  -- Name fallback
-  if not mapID and type(info) == "table" then
-    local listName = info.name or ""
-    if listName == "" then
-      listName = (info.comment or "") .. " " .. (info.voiceChat or "")
-    end
-    mapID = MatchMapIDFromName(listName)
-  end
-
   if mapID then
     pendingInvites[searchResultID] = mapID
   end
 end
 
--- BUG-1 fix: soundContext propagated so own-queue updates suppress the portal sound.
+-- BUG-1 fix: soundContext propagated so own-queue and invite updates suppress the portal sound.
 -- ARCH-1 fix: uses the injected highlightCallback instead of reaching into _factoryCtx.
-local function TriggerHighlightUpdate(soundContext)
+TriggerHighlightUpdate = function(soundContext)
   if type(highlightCallback) == "function" then
     highlightCallback(soundContext)
   end
@@ -238,16 +161,23 @@ end
 local function OnInviteAccepted(searchResultID)
   local mapID = pendingInvites[searchResultID]
   if mapID then
-    detectedMapID = mapID
-    local L = localeGetter and localeGetter() or {}
-    Print(string.format(L.LFG_DETECT_INVITE or "LFG invite detected: %s", GetDungeonName(mapID)))
-    pendingInvites = {}
-    TriggerHighlightUpdate() -- no soundContext: portal sound is intended for accepted invites
+    pendingInvites[searchResultID] = nil
+    if detectedMapID ~= mapID then
+      detectedMapID = mapID
+      local L = localeGetter and localeGetter() or {}
+      Print(string.format(L.LFG_DETECT_INVITE or "LFG invite detected: %s", GetDungeonName(mapID)))
+      TriggerHighlightUpdate("invite")
+    end
   end
 end
 
 local function OnInviteDeclined(searchResultID)
+  local mapID = pendingInvites[searchResultID]
   pendingInvites[searchResultID] = nil
+  if mapID and detectedMapID == mapID then
+    detectedMapID = nil
+    TriggerHighlightUpdate("queue")
+  end
 end
 
 local NEGATIVE_STATUSES = {
@@ -329,9 +259,6 @@ local function CheckActiveGroup()
   if not mapID and info.activityID then
     mapID = MapIDFromActivityID(info.activityID)
   end
-  if not mapID and type(info.name) == "string" then
-    mapID = MatchMapIDFromName(info.name)
-  end
 
   if mapID and mapID ~= lastQueueMapID then
     lastQueueMapID = mapID
@@ -384,10 +311,10 @@ frame:SetScript("OnEvent", function(_self, event, ...)
       local resultID, mapID = next(pendingInvites)
       if resultID and mapID then
         detectedMapID = mapID
+        pendingInvites[resultID] = nil
         local L = localeGetter and localeGetter() or {}
         Print(string.format(L.LFG_DETECT_INVITE or "LFG invite detected: %s", GetDungeonName(mapID)))
-        pendingInvites = {}
-        TriggerHighlightUpdate() -- no soundContext: portal sound intended here
+        TriggerHighlightUpdate("invite")
       else
         CheckActiveGroup()
       end

--- a/game/isiLive_lfg_detect.lua
+++ b/game/isiLive_lfg_detect.lua
@@ -100,7 +100,7 @@ local highlightCallback = nil
 -- Injected by the factory so chat messages follow the player's locale setting.
 -- MINOR-1 fix: removes hardcoded German strings.
 local localeGetter = nil
-local TriggerHighlightUpdate = nil
+local TriggerHighlightUpdate
 
 function LFGDetect.GetDetectedMapID()
   return detectedMapID

--- a/isiLive.toc
+++ b/isiLive.toc
@@ -1,8 +1,8 @@
 ## Interface: 120001
-## Title: isiLive v0.9.151
+## Title: isiLive v0.9.153
 ## Notes: M+ Dungeon and Group Managment
 ## Author: mematiWoW
-## Version: 0.9.151
+## Version: 0.9.153
 ## SavedVariables: IsiLiveDB
 ## IconTexture: Interface\Icons\INV_Misc_QuestionMark
 core/isiLive_validation_helpers.lua

--- a/testmodul/isilive_test_scenarios_lfg_detect.lua
+++ b/testmodul/isilive_test_scenarios_lfg_detect.lua
@@ -210,7 +210,11 @@ local function RegisterLFGDetectResolutionTests(test, ctx)
 
       fire("LFG_LIST_APPLICATION_STATUS_UPDATED", 1, "inviteaccepted")
 
-      Assert.Equal(addon.LFGDetect.GetDetectedMapID(), 557, "inviteaccepted must set detectedMapID from the pending invite")
+      Assert.Equal(
+        addon.LFGDetect.GetDetectedMapID(),
+        557,
+        "inviteaccepted must set detectedMapID from the pending invite"
+      )
       Assert.Equal(#callbackSoundContexts, 1, "highlight callback must fire once on inviteaccepted")
       Assert.Equal(
         callbackSoundContexts[1],
@@ -274,7 +278,10 @@ local function RegisterLFGDetectResolutionTests(test, ctx)
 
       fire("LFG_LIST_ACTIVE_ENTRY_UPDATE")
 
-      Assert.Nil(addon.LFGDetect.GetDetectedMapID(), "active listing must stay unresolved without exact activity mapping")
+      Assert.Nil(
+        addon.LFGDetect.GetDetectedMapID(),
+        "active listing must stay unresolved without exact activity mapping"
+      )
       Assert.Equal(callbackCount, 0, "unresolved active listing must not trigger a highlight update")
     end)
   end)

--- a/testmodul/isilive_test_scenarios_lfg_detect.lua
+++ b/testmodul/isilive_test_scenarios_lfg_detect.lua
@@ -98,8 +98,8 @@ local function RegisterLFGDetectResolutionTests(test, ctx)
     end)
   end)
 
-  test("LFGDetect resolves mapID from dungeon name keyword when activityID is unknown", function()
-    -- activityID 9999 is not in ACTIVITY_TO_MAP; name keyword fallback must fire.
+  test("LFGDetect keeps unknown invite activity unresolved instead of guessing from dungeon name", function()
+    -- activityID 9999 is not in ACTIVITY_TO_MAP; name text must not be used as a fallback.
     local globals, fire = BuildLFGDetectEnv({
       globals = {
         C_LFGList = BuildC_LFGList({
@@ -110,11 +110,16 @@ local function RegisterLFGDetectResolutionTests(test, ctx)
 
     WithGlobals(globals, function()
       local addon = LoadAddonModules({ "isiLive_lfg_detect.lua" })
+      local callbackCount = 0
+      addon.LFGDetect.SetHighlightCallback(function()
+        callbackCount = callbackCount + 1
+      end)
 
       fire("LFG_LIST_APPLICATION_STATUS_UPDATED", 1, "invited")
       fire("LFG_LIST_APPLICATION_STATUS_UPDATED", 1, "inviteaccepted")
 
-      Assert.Equal(addon.LFGDetect.GetDetectedMapID(), 557, "name keyword 'windrunner' must resolve to mapID 557")
+      Assert.Nil(addon.LFGDetect.GetDetectedMapID(), "unknown activityID must stay unresolved without name fallback")
+      Assert.Equal(callbackCount, 0, "unresolved invite must not trigger a highlight update")
     end)
   end)
 
@@ -182,10 +187,8 @@ local function RegisterLFGDetectResolutionTests(test, ctx)
   -- Invite callback behavior (BUG-1, ARCH-1)
   -- ---------------------------------------------------------------------------
 
-  test("LFGDetect invite accepted sets detectedMapID and callback fires on key start", function()
-    -- TriggerHighlightUpdate() with nil soundContext is called on invite accept.
-    -- Verify the invite flow sets detectedMapID, then confirm the callback mechanism
-    -- works by firing CHALLENGE_MODE_START (ClearAllState â†’ TriggerHighlightUpdate(\"queue\"))."
+  test("LFGDetect exact invite stays pending until inviteaccepted and then highlights without sound", function()
+    -- Incoming invites must stay pending until the exact activity data is confirmed.
     local callbackSoundContexts = {}
 
     local globals, fire = BuildLFGDetectEnv({
@@ -201,16 +204,26 @@ local function RegisterLFGDetectResolutionTests(test, ctx)
       end)
 
       fire("LFG_LIST_APPLICATION_STATUS_UPDATED", 1, "invited")
+
+      Assert.Nil(addon.LFGDetect.GetDetectedMapID(), "invite must stay pending until inviteaccepted")
+      Assert.Equal(#callbackSoundContexts, 0, "pending invite must not trigger a highlight update yet")
+
       fire("LFG_LIST_APPLICATION_STATUS_UPDATED", 1, "inviteaccepted")
 
-      Assert.Equal(addon.LFGDetect.GetDetectedMapID(), 557, "invite accept must set detectedMapID to 557")
+      Assert.Equal(addon.LFGDetect.GetDetectedMapID(), 557, "inviteaccepted must set detectedMapID from the pending invite")
+      Assert.Equal(#callbackSoundContexts, 1, "highlight callback must fire once on inviteaccepted")
+      Assert.Equal(
+        callbackSoundContexts[1],
+        "invite",
+        "inviteaccepted callback must use soundContext='invite' to suppress portal sound"
+      )
 
       -- Key start clears all state and fires TriggerHighlightUpdate("queue")
       fire("CHALLENGE_MODE_START")
 
       Assert.Nil(addon.LFGDetect.GetDetectedMapID(), "CHALLENGE_MODE_START must clear detectedMapID")
-      Assert.Equal(#callbackSoundContexts, 1, "highlight callback must fire on state clear")
-      Assert.Equal(callbackSoundContexts[1], "queue", "state-clear callback must pass soundContext='queue'")
+      Assert.Equal(#callbackSoundContexts, 2, "state clear must trigger a second callback")
+      Assert.Equal(callbackSoundContexts[2], "queue", "state-clear callback must pass soundContext='queue'")
     end)
   end)
 
@@ -242,6 +255,27 @@ local function RegisterLFGDetectResolutionTests(test, ctx)
         "queue",
         "own-listing callback must pass soundContext='queue' to suppress portal sound"
       )
+    end)
+  end)
+
+  test("LFGDetect active listing stays unresolved when only dungeon name text is available", function()
+    local globals, fire = BuildLFGDetectEnv({
+      globals = {
+        C_LFGList = BuildC_LFGList({}, { activityID = 9999, name = "Windrunner Spire" }),
+      },
+    })
+
+    WithGlobals(globals, function()
+      local addon = LoadAddonModules({ "isiLive_lfg_detect.lua" })
+      local callbackCount = 0
+      addon.LFGDetect.SetHighlightCallback(function()
+        callbackCount = callbackCount + 1
+      end)
+
+      fire("LFG_LIST_ACTIVE_ENTRY_UPDATE")
+
+      Assert.Nil(addon.LFGDetect.GetDetectedMapID(), "active listing must stay unresolved without exact activity mapping")
+      Assert.Equal(callbackCount, 0, "unresolved active listing must not trigger a highlight update")
     end)
   end)
 

--- a/testmodul/isilive_test_scenarios_teleport.lua
+++ b/testmodul/isilive_test_scenarios_teleport.lua
@@ -1742,6 +1742,94 @@ local function RegisterTeleportUIAudioAndDebugTests(test, Assert, WithGlobals, L
     end)
   end)
 
+  test("TeleportUI suppresses portal sound for invite-driven active target refreshes", function()
+    local createFrameStub = BuildTeleportUICreateFrameStub()
+    local soundCalls = 0
+
+    WithGlobals({
+      CreateFrame = createFrameStub,
+      PlaySoundFile = function()
+        soundCalls = soundCalls + 1
+      end,
+    }, function()
+      local addon = LoadAddonModules({
+        "isiLive_ui_common.lua",
+        "isiLive_teleport_ui.lua",
+      })
+
+      local controller = addon.TeleportUI.CreateController({
+        mainFrame = {
+          GetFrameLevel = function()
+            return 10
+          end,
+          GetFrameStrata = function()
+            return "MEDIUM"
+          end,
+          CreateFontString = function()
+            return {
+              SetPoint = function() end,
+              SetWidth = function() end,
+              SetJustifyH = function() end,
+              SetJustifyV = function() end,
+              SetTextColor = function() end,
+              SetWordWrap = function() end,
+              SetNonSpaceWrap = function() end,
+              SetText = function() end,
+              Hide = function() end,
+              Show = function() end,
+            }
+          end,
+        },
+        layoutMode = "compact_main_horizontal",
+        applySecureSpellToButton = function()
+          return true
+        end,
+        getEntries = function()
+          return {
+            { spellID = 12345, mapID = 558, slotIndex = 1 },
+          }
+        end,
+        getEmptyStateText = function()
+          return nil
+        end,
+        getL = function()
+          return {}
+        end,
+        isSpellKnown = function()
+          return true
+        end,
+        getTeleportCooldownRemaining = function()
+          return 0
+        end,
+        formatCooldownSeconds = function()
+          return ""
+        end,
+        getSpellCooldownSafe = function()
+          return 0, 0, false
+        end,
+        applyCooldownFrameSafe = function() end,
+        getSpellTexture = function()
+          return nil
+        end,
+        getDungeonShortCode = function(mapID)
+          if mapID == 558 then
+            return "MT"
+          end
+          return nil
+        end,
+        isInCombat = function()
+          return false
+        end,
+      })
+
+      controller.BuildButtons()
+      controller.UpdateButtons(nil, "invite")
+      controller.UpdateButtons(12345, "invite")
+
+      Assert.Equal(soundCalls, 0, "invite-driven target refreshes must not play the portal sound")
+    end)
+  end)
+
   test("Teleport debug output labels short cooldowns as GCD", function()
     local prints = {}
 

--- a/ui/isiLive_teleport_ui.lua
+++ b/ui/isiLive_teleport_ui.lua
@@ -26,7 +26,7 @@ local function PlayPortalAvailableSound()
 end
 
 local function ShouldSuppressPortalSound(soundContext)
-  return soundContext == "queue"
+  return soundContext == "queue" or soundContext == "invite"
 end
 
 local LAYOUT_MODE_EXPANDED = RI.LAYOUT_MODE_EXPANDED or "expanded"


### PR DESCRIPTION
## What changed\n- Removed dungeon-name and token-based fallback resolution from LFG detection.\n- Changed invite handling to stay pending until exact activity confirmation.\n- Updated tests and documentation to enforce the no-guess contract.\n\n## Why\n- The previous flow still guessed in a few runtime paths, which caused intermittent wrong invite/portal behavior.\n- The new flow fails closed when exact activity data is not available.\n\n## Validation\n- lua tools/validate_usecases.lua\n- Result: 559 passed, 0 failed\n